### PR TITLE
feat: Click on the date to add the bill

### DIFF
--- a/src/components/bill-editor/index.tsx
+++ b/src/components/bill-editor/index.tsx
@@ -1,3 +1,4 @@
+import type { EditBill } from "@/store/ledger";
 import { useLedgerStore } from "@/store/ledger";
 import createConfirmProvider from "../confirm";
 import EditorForm from "./form";
@@ -11,7 +12,9 @@ export const [BillEditorProvider, showBillEditor] = createConfirmProvider(
     },
 );
 
-export const goAddBill = async () => {
-    const newBill = await showBillEditor();
+export const goAddBill = async (
+    initialData?: Partial<Pick<EditBill, "time">>,
+) => {
+    const newBill = await showBillEditor(initialData as EditBill | undefined);
     await useLedgerStore.getState().addBill(newBill);
 };

--- a/src/components/ledger/index.tsx
+++ b/src/components/ledger/index.tsx
@@ -7,14 +7,26 @@ import type { OutputType } from "@/database/stash";
 import type { Bill } from "@/ledger/type";
 import { cn } from "@/utils";
 import { denseDate } from "@/utils/time";
+import { goAddBill } from "../bill-editor";
 import { showBillInfo } from "../bill-info";
 import { Checkbox } from "../ui/checkbox";
 import BillItem from "./item";
 import "./style.scss";
 
 function Divider({ date: day }: { date: Dayjs }) {
+    const handleDateClick = async () => {
+        /** 使用点击日期的时间戳作为新账单的时间 **/
+        await goAddBill({
+            time: day.startOf("day").valueOf(),
+        });
+    };
     return (
-        <div className={"pl-12 pr-4 pt-4 pb-2 text-sm ledger-divider"}>
+        <div
+            className={
+                "pl-12 pr-4 pt-4 pb-2 text-sm ledger-divider cursor-pointer hover:opacity-70 transition-opacity"
+            }
+            onClick={handleDateClick}
+        >
             {denseDate(day)}
         </div>
     );


### PR DESCRIPTION
During the use of Cent, if I want to add historical bills, I have to click "Add Bill" and then select the date. This operation is extremely inconvenient. Therefore, I added a click event to the timeline, which triggers the "Add Bill" pop-up window and passes the date value over.