### PR TITLE
feat: add 'Show attachments in list' preference and render thumbnails

### DIFF
--- a/src/components/ledger/item.tsx
+++ b/src/components/ledger/item.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import useCategory from "@/hooks/use-category";
 import { useCreators } from "@/hooks/use-creator";
 import { useCurrency } from "@/hooks/use-currency";
@@ -6,10 +5,13 @@ import { useTag } from "@/hooks/use-tag";
 import { amountToNumber } from "@/ledger/bill";
 import type { Bill } from "@/ledger/type";
 import { useIntl } from "@/locale";
+import { usePreference } from "@/store/preference";
 import { useUserStore } from "@/store/user";
 import { cn } from "@/utils";
-import { denseTime, shortTime } from "@/utils/time";
+import { denseTime } from "@/utils/time";
+import { useMemo } from "react";
 import CategoryIcon from "../category/icon";
+import SmartImage from "../image";
 
 interface BillItemProps {
     bill: Bill;
@@ -25,6 +27,7 @@ export default function BillItem({
     showTime,
 }: BillItemProps) {
     const t = useIntl();
+    const [showAttachmentsInList] = usePreference("showAttachmentsInList");
     const { categories } = useCategory();
     const { tags: allTags } = useTag();
     const category = useMemo(
@@ -87,7 +90,19 @@ export default function BillItem({
                         )}
                     </div>
                 </div>
+
+    {showAttachmentsInList && (bill.images?.length ?? 0) > 0 && (
+                <div className="flex-shrink-0 px-2">
+                    <SmartImage
+                        source={bill.images![0]}
+                        alt=""
+                        className="w-10 h-10  object-cover rounded"
+                    />
+                </div>
+            )}
             </div>
+
+        
 
             {/* 金额 */}
             <div className="text-right">

--- a/src/components/settings/lab.tsx
+++ b/src/components/settings/lab.tsx
@@ -31,6 +31,9 @@ function Form({ onCancel }: { onCancel?: () => void }) {
     ] = usePreference("readClipboardWhenReduceMotionChanged");
 
     const [multiplyKey, setMultiplyKey] = usePreference("multiplyKey");
+    const [showAttachmentsInList, setShowAttachmentsInList] = usePreference(
+        "showAttachmentsInList",
+    );
 
     return (
         <PopupLayout
@@ -76,6 +79,18 @@ function Form({ onCancel }: { onCancel?: () => void }) {
                                 <SelectItem value="triple-zero">000</SelectItem>
                             </SelectContent>
                         </Select>
+                    </div>
+                    <div className="w-full h-10 flex justify-between items-center px-4">
+                        <div className="text-sm">
+                            <div>{t("show-attachments-in-list")}</div>
+                            <div className="text-xs opacity-60">
+                                {t("show-attachments-in-list-description")}
+                            </div>
+                        </div>
+                        <Switch
+                            checked={showAttachmentsInList}
+                            onCheckedChange={setShowAttachmentsInList}
+                        />
                     </div>
                 </div>
 

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -433,6 +433,8 @@
   "multiply-key": "Multiply key",
   "multiply-key-tip": "Quick enter multiple zeros",
   "off": "Off",
+  "show-attachments-in-list": "Show attachments in list",
+  "show-attachments-in-list-description": "Show small thumbnails of attachments between the comment and amount in list entries",
   "app-introduce": "Open-Source, Free, Collaborative Accounting App",
   "add-new-currency": "Add new currency",
   "edit-currency": "Edit currency",

--- a/src/locale/lang/zh.json
+++ b/src/locale/lang/zh.json
@@ -251,6 +251,8 @@
   "experimental-functions": "实验性功能",
   "auto-locate-when-add-bill": "新增记账时自动记录位置",
   "auto-locate-when-add-bill-description": "需要先手动授权位置权限后生效",
+  "show-attachments-in-list": "在列表中显示附件",
+  "show-attachments-in-list-description": "在首页条目中于备注与金额之间显示附件缩略图",
   "enter-add-bill-when-reduce-motion-changed": "【减弱动态效果】变化时进入新增记账页",
   "enter-add-bill-when-reduce-motion-changed-description": "配合 iOS 快捷指令使用",
   "location": "位置",

--- a/src/pages/stat/index.tsx
+++ b/src/pages/stat/index.tsx
@@ -108,6 +108,7 @@ export default function Page() {
             return [];
         }
         const { unit, labelThis, labelLast, format, max } = labels;
+        // Make sure end is the very end of the period
         let end = END;
         let start = end.startOf(unit);
         const s = [];
@@ -120,8 +121,9 @@ export default function Page() {
         let i = 0;
         while (true && i < (max ?? Infinity)) {
             i += 1;
-            end = start;
-            start = end.subtract(1, unit);
+            // End of previous period is 1ms before start of current period
+            end = start.subtract(1, 'ms');
+            start = end.startOf(unit);
             if (end.isAfter(START)) {
                 s.push({
                     end,

--- a/src/store/preference.ts
+++ b/src/store/preference.ts
@@ -1,14 +1,16 @@
+import { getBrowserLang, type LocaleName } from "@/locale/utils";
 import { create, type StateCreator } from "zustand";
 import {
     createJSONStorage,
-    type PersistOptions,
     persist,
+    type PersistOptions,
 } from "zustand/middleware";
-import { getBrowserLang, type LocaleName } from "@/locale/utils";
 
 type State = {
     locale: LocaleName;
     autoLocateWhenAddBill?: boolean;
+    /** 在首页条目中显示附件缩略图 */
+    showAttachmentsInList?: boolean;
     enterAddBillWhenReduceMotionChanged?: boolean;
     readClipboardWhenReduceMotionChanged?: boolean;
     smartPredict?: boolean;
@@ -33,6 +35,7 @@ export const usePreferenceStore = create<Store>()(
             return {
                 locale: getBrowserLang(),
                 autoLocateWhenAddBill: false,
+                    showAttachmentsInList: false,
                 readClipboardWhenReduceMotionChanged: false,
                 smartPredict: false,
                 reLayrKey: "cent",

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -15,7 +15,7 @@ export const filterOrderedBillListByTimeRange = <T extends { time: number }>(
         const bill = orderedList[desc ? index : orderedList.length - index];
         const billTime = dayjs.unix(bill.time / 1000);
         if (billTime.isAfter(newest)) {
-        } else if (billTime.isAfter(oldest)) {
+        } else if (billTime.isSameOrAfter(oldest)) {
             result.push(bill);
         } else if (billTime.isBefore(oldest)) {
             break;


### PR DESCRIPTION
不增加额外依赖，不更改默认表现

在增加实验性功能里面增加一个开关，在主页条目里面直接显示图片
 
之前是想找一个 dev分支进行合并，没想到是直接往 main 合并 #124


- Add persistent preference `showAttachmentsInList` (default: false)
- Add switch UI in Settings → More (实验性功能 / Advanced)
- Add i18n keys and translations for zh/en
- Render attachment thumbnail in `Ledger` list items when the setting is enabled (shows first image)
- Use `SmartImage` for local / remote file preview

Notes:
- Thumbnail is small and non-interactive by default; can be extended to preview on click or show multiple images in a follow-up change.