### PR TITLE
fix: dayjs monthly statistics boundary issue #107

### DIFF
--- a/src/pages/stat/index.tsx
+++ b/src/pages/stat/index.tsx
@@ -108,6 +108,7 @@ export default function Page() {
             return [];
         }
         const { unit, labelThis, labelLast, format, max } = labels;
+        // Make sure end is the very end of the period
         let end = END;
         let start = end.startOf(unit);
         const s = [];
@@ -120,8 +121,9 @@ export default function Page() {
         let i = 0;
         while (true && i < (max ?? Infinity)) {
             i += 1;
-            end = start;
-            start = end.subtract(1, unit);
+            // End of previous period is 1ms before start of current period
+            end = start.subtract(1, 'ms');
+            start = end.startOf(unit);
             if (end.isAfter(START)) {
                 s.push({
                     end,

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -15,7 +15,7 @@ export const filterOrderedBillListByTimeRange = <T extends { time: number }>(
         const bill = orderedList[desc ? index : orderedList.length - index];
         const billTime = dayjs.unix(bill.time / 1000);
         if (billTime.isAfter(newest)) {
-        } else if (billTime.isAfter(oldest)) {
+        } else if (billTime.isSameOrAfter(oldest)) {
             result.push(bill);
         } else if (billTime.isBefore(oldest)) {
             break;


### PR DESCRIPTION
isAfter 改成 isSameOrAfter
#107

```js
        } else if (billTime.isAfter(oldest)) {
        } else if (billTime.isSameOrAfter(oldest)) {
```