### PR TITLE
fix: support currentColor for custom SVG category icons

### DIFF
--- a/src/components/category/icon.tsx
+++ b/src/components/category/icon.tsx
@@ -11,21 +11,15 @@ export default function CategoryIcon({
     const isSvgString = icon.trim().startsWith("<svg");
 
     if (isSvgString) {
-        // 用 data-uri 转换成 <img> 的 src
-        const svgSrc = "data:image/svg+xml;utf8," + encodeURIComponent(icon);
         return (
             <i
                 className={cn(
-                    "flex items-center justify-center min-w-4 min-h-4",
+                    "flex items-center justify-center min-w-4 min-h-4 [&>svg]:w-[1em] [&>svg]:h-[1em]",
                     className,
                 )}
-                style={{
-                    backgroundImage: `url(${svgSrc})`,
-                    backgroundSize: "contain",
-                    backgroundPosition: "center",
-                    backgroundRepeat: "no-repeat",
-                }}
-            ></i>
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: SVG string needs inline rendering to support currentColor
+                dangerouslySetInnerHTML={{ __html: icon }}
+            />
         );
     }
 


### PR DESCRIPTION
很好用的开源记账工具！

因为个人习惯深色模式，在使用过程中发现 CategoryIcon 组件对于自定义 SVG 采用 background-image (Data URI) 的方式进行渲染。这种方式会导致 SVG 脱离文档流上下文，无法通过 CSS 的 currentColor 属性继承父元素的文字颜色。在深色模式下，这会导致自定义图标颜色固定（字体是白的图标是固定的黑色），无法随主题自动切换，影响视觉一致性，如图：
<table>
<tr>
<td><img width="446" height="242" alt="image" src="https://github.com/user-attachments/assets/afb1d318-063e-464d-b3ce-084df73cdd85" /></td>
<td><img width="441" height="237" alt="image" src="https://github.com/user-attachments/assets/55a50d29-86ad-4877-8208-f12082de8ca4" /></td>
</tr>
</table>


所以我尝试使用dangerouslySetInnerHTML来直接将svg注入文档流让他能吃到css继承下来的颜色，好处是以后主题啥的上了也能自动跟上颜色，以及万一用户想用一点花里胡哨颜色的svg也不会有啥影响。

但是毕竟直接插了html，对于可能存在的安全影响可能需要作者评估一下。我是感觉目前的架构分类图标数据主要来源于用户自身以及从共享者上传的数据同步，只可能存在用户自攻的风险，但如果仓库之后引入了主题同步功能的话，就需要作者评估一下了~