### PR TITLE
fix: possible custom category creation causing i18n error

### DIFF
--- a/src/hooks/use-category.ts
+++ b/src/hooks/use-category.ts
@@ -93,9 +93,12 @@ export default function useCategory() {
                     return prev;
                 }
                 // 如果是默认分类，并且名称与intl后的名称不同，customName设为true，否则为undefined
-                let customName: boolean | undefined;
+                // 如果是用户自建分类（不在 BillCategories 里），保留原有的 customName（true）
+                const existingCategory = prev.categories[index];
+                let customName: boolean | undefined =
+                    existingCategory.customName;
                 const defaultCategory = BillCategories.find((c) => c.id === id);
-                if (defaultCategory && defaultCategory) {
+                if (defaultCategory) {
                     customName = t(defaultCategory.name) !== value.name;
                 }
                 prev.categories[index] = {


### PR DESCRIPTION
测自定义svg的时候发现的
<img width="455" height="414" alt="image" src="https://github.com/user-attachments/assets/77347353-d59c-4081-93d1-717d409e5614" />

对普通用户没啥影响，开发者也只是有概率触发
而且以前添加的也影响不到

其实我寻思最好还是给t（i18n翻译函数）加一个默认输出的参数省的他报错就行了