### PR TITLE
feat: keyboard height free resize

### DIFF
--- a/src/components/bill-editor/form.tsx
+++ b/src/components/bill-editor/form.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import useCategory from "@/hooks/use-category";
 import { useCurrency } from "@/hooks/use-currency";
+import { useIsDesktop } from "@/hooks/use-media-query";
 import { useTag } from "@/hooks/use-tag";
 import { useWheelScrollX } from "@/hooks/use-wheel-scroll";
 import PopupLayout from "@/layouts/popup-layout";
@@ -44,6 +45,37 @@ const defaultBill = {
     categoryId: ExpenseBillCategories[0].id,
 };
 
+type KeyboardHeightBounds = {
+    min: number;
+    max: number;
+};
+
+const normalizeKeyboardHeightPercent = (value: number) =>
+    Math.max(0, Math.min(100, Math.round(value)));
+
+const getKeyboardHeightBounds = (isDesktop: boolean): KeyboardHeightBounds => {
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    if (isDesktop) {
+        return {
+            min: 280,
+            max: Math.min(
+                460,
+                Math.max(360, Math.round(viewportHeight * 0.56)),
+            ),
+        };
+    }
+    const min = Math.round(Math.min(300, Math.max(280, viewportHeight * 0.36)));
+    const max = Math.round(
+        Math.min(520, Math.max(min + 100, viewportHeight * 0.62)),
+    );
+    return { min, max };
+};
+
+const getKeyboardHeight = (percent: number, bounds: KeyboardHeightBounds) => {
+    const ratio = normalizeKeyboardHeightPercent(percent) / 100;
+    return Math.round(bounds.min + (bounds.max - bounds.min) * ratio);
+};
+
 export default function EditorForm({
     edit,
     onCancel,
@@ -54,6 +86,7 @@ export default function EditorForm({
     onCancel?: () => void;
 }) {
     const t = useIntl();
+    const isDesktop = useIsDesktop();
     const goBack = () => {
         onCancel?.();
     };
@@ -213,6 +246,71 @@ export default function EditorForm({
 
     const tagSelectorRef = useRef<HTMLDivElement>(null);
     useWheelScrollX(tagSelectorRef);
+    const [keyboardHeightPercent, setKeyboardHeightPercent] = useState(() =>
+        normalizeKeyboardHeightPercent(
+            usePreferenceStore.getState().keyboardHeight ?? 50,
+        ),
+    );
+    const [keyboardHeightBounds, setKeyboardHeightBounds] = useState(() =>
+        getKeyboardHeightBounds(isDesktop),
+    );
+    const keyboardDragRef = useRef<{
+        pointerId: number;
+        startY: number;
+        startPercent: number;
+        lastPercent: number;
+    } | null>(null);
+
+    const persistKeyboardHeight = useCallback((value: number) => {
+        const next = normalizeKeyboardHeightPercent(value);
+        setKeyboardHeightPercent(next);
+        usePreferenceStore.setState((prev) => ({
+            ...prev,
+            keyboardHeight: next,
+        }));
+    }, []);
+
+    useEffect(() => {
+        const updateBounds = () => {
+            setKeyboardHeightBounds(getKeyboardHeightBounds(isDesktop));
+        };
+        updateBounds();
+
+        const viewport = window.visualViewport;
+        window.addEventListener("resize", updateBounds);
+        viewport?.addEventListener("resize", updateBounds);
+
+        return () => {
+            window.removeEventListener("resize", updateBounds);
+            viewport?.removeEventListener("resize", updateBounds);
+        };
+    }, [isDesktop]);
+
+    const keyboardHeight = useMemo(
+        () => getKeyboardHeight(keyboardHeightPercent, keyboardHeightBounds),
+        [keyboardHeightBounds, keyboardHeightPercent],
+    );
+
+    const updateKeyboardDrag = useCallback(
+        (clientY: number) => {
+            const drag = keyboardDragRef.current;
+            if (!drag) {
+                return;
+            }
+            const distance =
+                keyboardHeightBounds.max - keyboardHeightBounds.min;
+            if (distance <= 0) {
+                return;
+            }
+            const next = normalizeKeyboardHeightPercent(
+                drag.startPercent + ((drag.startY - clientY) / distance) * 100,
+            );
+            drag.lastPercent = next;
+            setKeyboardHeightPercent(next);
+        },
+        [keyboardHeightBounds],
+    );
+
     return (
         <Calculator.Root
             multiplyKey={multiplyKey}
@@ -244,7 +342,7 @@ export default function EditorForm({
             input={monitorFocused}
         >
             <PopupLayout
-                className="h-full gap-2 pb-0 overflow-y-auto scrollbar-hidden"
+                className="h-full gap-2 pb-0 overflow-hidden"
                 onBack={goBack}
                 title={
                     <div className="pl-[54px] w-full min-h-12 rounded-lg flex pt-2 pb-0 overflow-hidden scrollbar-hidden">
@@ -339,8 +437,8 @@ export default function EditorForm({
                 }
             >
                 {/* categories */}
-                <div className="flex-1 flex-shrink-0 overflow-y-auto min-h-[80px] scrollbar-hidden flex flex-col px-2 text-sm font-medium gap-2">
-                    <div className="flex flex-col min-h-[80px] grow-[2] shrink overflow-y-auto scrollbar-hidden w-full">
+                <div className="flex-1 min-h-0 overflow-hidden scrollbar-hidden flex flex-col px-2 text-sm font-medium gap-2">
+                    <div className="flex flex-col min-h-0 grow-[2] shrink overflow-y-auto scrollbar-hidden w-full">
                         <div
                             className={cn(
                                 "grid gap-1",
@@ -375,7 +473,7 @@ export default function EditorForm({
                         </div>
                     </div>
                     {(subCategories?.length ?? 0) > 0 && (
-                        <div className="flex flex-col min-h-[68px] grow-[1] shrink max-h-fit overflow-y-auto rounded-md border p-2 shadow scrollbar-hidden">
+                        <div className="flex flex-col min-h-[68px] min-h-0 grow-[1] shrink overflow-y-auto rounded-md border p-2 shadow scrollbar-hidden">
                             <div
                                 className={cn(
                                     "grid gap-1",
@@ -439,10 +537,83 @@ export default function EditorForm({
                 {/* keyboard area */}
                 <div
                     className={cn(
-                        "h-[calc(480px+160px*(var(--bekh,0.5)-0.5))] sm:h-[calc(380px+160px*(var(--bekh,0.5)-0.5))] min-h-[264px] max-h-[calc(100%-124px)]",
                         "keyboard-field flex gap-2 flex-col justify-start bg-stone-900 sm:rounded-b-md text-[white] p-2 pb-[max(env(safe-area-inset-bottom),8px)]",
                     )}
+                    style={{ height: keyboardHeight }}
                 >
+                    <div className="flex justify-center">
+                        <div
+                            role="slider"
+                            aria-label={t("keyboard-height")}
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-valuenow={keyboardHeightPercent}
+                            tabIndex={0}
+                            className="flex h-4 w-16 touch-none select-none items-center justify-center rounded-full cursor-row-resize"
+                            onPointerDown={(e) => {
+                                keyboardDragRef.current = {
+                                    pointerId: e.pointerId,
+                                    startY: e.clientY,
+                                    startPercent: keyboardHeightPercent,
+                                    lastPercent: keyboardHeightPercent,
+                                };
+                                e.currentTarget.setPointerCapture(e.pointerId);
+                            }}
+                            onPointerMove={(e) => {
+                                if (
+                                    keyboardDragRef.current?.pointerId !==
+                                    e.pointerId
+                                ) {
+                                    return;
+                                }
+                                updateKeyboardDrag(e.clientY);
+                            }}
+                            onPointerUp={(e) => {
+                                if (
+                                    keyboardDragRef.current?.pointerId !==
+                                    e.pointerId
+                                ) {
+                                    return;
+                                }
+                                updateKeyboardDrag(e.clientY);
+                                persistKeyboardHeight(
+                                    keyboardDragRef.current.lastPercent,
+                                );
+                                keyboardDragRef.current = null;
+                                e.currentTarget.releasePointerCapture(
+                                    e.pointerId,
+                                );
+                            }}
+                            onPointerCancel={(e) => {
+                                if (
+                                    keyboardDragRef.current?.pointerId !==
+                                    e.pointerId
+                                ) {
+                                    return;
+                                }
+                                persistKeyboardHeight(
+                                    keyboardDragRef.current.lastPercent,
+                                );
+                                keyboardDragRef.current = null;
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === "ArrowUp") {
+                                    e.preventDefault();
+                                    persistKeyboardHeight(
+                                        keyboardHeightPercent + 5,
+                                    );
+                                }
+                                if (e.key === "ArrowDown") {
+                                    e.preventDefault();
+                                    persistKeyboardHeight(
+                                        keyboardHeightPercent - 5,
+                                    );
+                                }
+                            }}
+                        >
+                            <div className="h-1 w-12 rounded-full bg-white/25" />
+                        </div>
+                    </div>
                     <div className="flex justify-between items-center">
                         <div className="flex gap-2 items-center h-10">
                             <div className="flex items-center h-full">
@@ -450,7 +621,7 @@ export default function EditorForm({
                                     <div className="pr-2 flex gap-[6px] items-center overflow-x-auto max-w-22 h-full scrollbar-hidden">
                                         {billState.images?.map((img, index) => (
                                             <Deletable
-                                                // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                                                // biome-ignore lint/suspicious/noArrayIndexKey: image chips are rendered in selection order
                                                 key={index}
                                                 onDelete={() => {
                                                     setBillState((v) => ({
@@ -576,7 +747,7 @@ export default function EditorForm({
 
                     <button
                         type="button"
-                        className="flex h-[80px] min-h-[48px] justify-center items-center bg-green-700 rounded-lg font-bold text-lg cursor-pointer"
+                        className="flex h-14 sm:h-[80px] min-h-[48px] justify-center items-center bg-green-700 rounded-lg font-bold text-lg cursor-pointer"
                         onClick={toConfirm}
                     >
                         <i className="icon-[mdi--check] icon-md"></i>

--- a/src/components/bill-editor/form.tsx
+++ b/src/components/bill-editor/form.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import useCategory from "@/hooks/use-category";
 import { useCurrency } from "@/hooks/use-currency";
-import { useIsDesktop } from "@/hooks/use-media-query";
 import { useTag } from "@/hooks/use-tag";
 import { useWheelScrollX } from "@/hooks/use-wheel-scroll";
 import PopupLayout from "@/layouts/popup-layout";
@@ -11,7 +10,7 @@ import { amountToNumber, numberToAmount } from "@/ledger/bill";
 import { ExpenseBillCategories, IncomeBillCategories } from "@/ledger/category";
 import type { Bill } from "@/ledger/type";
 import { categoriesGridClassName } from "@/ledger/utils";
-import { useIntl, useLocale } from "@/locale";
+import { useIntl } from "@/locale";
 import type { EditBill } from "@/store/ledger";
 import { usePreferenceStore } from "@/store/preference";
 import { cn } from "@/utils";
@@ -27,53 +26,18 @@ import IOSUnscrolledInput from "../input";
 import Calculator from "../keyboard";
 import CurrentLocation from "../simple-location";
 import Tag from "../tag";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "../ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "../ui/select";
 import { goAddBill } from ".";
+import KeyboardHeightHandle from "./keyboard-height-handle";
 import { RemarkHint } from "./remark";
 import TagGroupSelector from "./tag-group";
+import { useKeyboardHeight } from "./use-keyboard-height";
 
 const defaultBill = {
     type: "expense" as Bill["type"],
     comment: "",
     amount: 0,
     categoryId: ExpenseBillCategories[0].id,
-};
-
-type KeyboardHeightBounds = {
-    min: number;
-    max: number;
-};
-
-const normalizeKeyboardHeightPercent = (value: number) =>
-    Math.max(0, Math.min(100, Math.round(value)));
-
-const getKeyboardHeightBounds = (isDesktop: boolean): KeyboardHeightBounds => {
-    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-    if (isDesktop) {
-        return {
-            min: 280,
-            max: Math.min(
-                460,
-                Math.max(360, Math.round(viewportHeight * 0.56)),
-            ),
-        };
-    }
-    const min = Math.round(Math.min(300, Math.max(280, viewportHeight * 0.36)));
-    const max = Math.round(
-        Math.min(520, Math.max(min + 100, viewportHeight * 0.62)),
-    );
-    return { min, max };
-};
-
-const getKeyboardHeight = (percent: number, bounds: KeyboardHeightBounds) => {
-    const ratio = normalizeKeyboardHeightPercent(percent) / 100;
-    return Math.round(bounds.min + (bounds.max - bounds.min) * ratio);
 };
 
 export default function EditorForm({
@@ -86,7 +50,6 @@ export default function EditorForm({
     onCancel?: () => void;
 }) {
     const t = useIntl();
-    const isDesktop = useIsDesktop();
     const goBack = () => {
         onCancel?.();
     };
@@ -134,8 +97,6 @@ export default function EditorForm({
         }
         return init;
     });
-
-    const { grouped } = useTag();
 
     const categories = billState.type === "expense" ? expenses : incomes;
 
@@ -246,70 +207,8 @@ export default function EditorForm({
 
     const tagSelectorRef = useRef<HTMLDivElement>(null);
     useWheelScrollX(tagSelectorRef);
-    const [keyboardHeightPercent, setKeyboardHeightPercent] = useState(() =>
-        normalizeKeyboardHeightPercent(
-            usePreferenceStore.getState().keyboardHeight ?? 50,
-        ),
-    );
-    const [keyboardHeightBounds, setKeyboardHeightBounds] = useState(() =>
-        getKeyboardHeightBounds(isDesktop),
-    );
-    const keyboardDragRef = useRef<{
-        pointerId: number;
-        startY: number;
-        startPercent: number;
-        lastPercent: number;
-    } | null>(null);
-
-    const persistKeyboardHeight = useCallback((value: number) => {
-        const next = normalizeKeyboardHeightPercent(value);
-        setKeyboardHeightPercent(next);
-        usePreferenceStore.setState((prev) => ({
-            ...prev,
-            keyboardHeight: next,
-        }));
-    }, []);
-
-    useEffect(() => {
-        const updateBounds = () => {
-            setKeyboardHeightBounds(getKeyboardHeightBounds(isDesktop));
-        };
-        updateBounds();
-
-        const viewport = window.visualViewport;
-        window.addEventListener("resize", updateBounds);
-        viewport?.addEventListener("resize", updateBounds);
-
-        return () => {
-            window.removeEventListener("resize", updateBounds);
-            viewport?.removeEventListener("resize", updateBounds);
-        };
-    }, [isDesktop]);
-
-    const keyboardHeight = useMemo(
-        () => getKeyboardHeight(keyboardHeightPercent, keyboardHeightBounds),
-        [keyboardHeightBounds, keyboardHeightPercent],
-    );
-
-    const updateKeyboardDrag = useCallback(
-        (clientY: number) => {
-            const drag = keyboardDragRef.current;
-            if (!drag) {
-                return;
-            }
-            const distance =
-                keyboardHeightBounds.max - keyboardHeightBounds.min;
-            if (distance <= 0) {
-                return;
-            }
-            const next = normalizeKeyboardHeightPercent(
-                drag.startPercent + ((drag.startY - clientY) / distance) * 100,
-            );
-            drag.lastPercent = next;
-            setKeyboardHeightPercent(next);
-        },
-        [keyboardHeightBounds],
-    );
+    const { keyboardHeight, onPointerDown, onPointerMove, onPointerUp } =
+        useKeyboardHeight();
 
     return (
         <Calculator.Root
@@ -541,79 +440,11 @@ export default function EditorForm({
                     )}
                     style={{ height: keyboardHeight }}
                 >
-                    <div className="flex justify-center">
-                        <div
-                            role="slider"
-                            aria-label={t("keyboard-height")}
-                            aria-valuemin={0}
-                            aria-valuemax={100}
-                            aria-valuenow={keyboardHeightPercent}
-                            tabIndex={0}
-                            className="flex h-4 w-16 touch-none select-none items-center justify-center rounded-full cursor-row-resize"
-                            onPointerDown={(e) => {
-                                keyboardDragRef.current = {
-                                    pointerId: e.pointerId,
-                                    startY: e.clientY,
-                                    startPercent: keyboardHeightPercent,
-                                    lastPercent: keyboardHeightPercent,
-                                };
-                                e.currentTarget.setPointerCapture(e.pointerId);
-                            }}
-                            onPointerMove={(e) => {
-                                if (
-                                    keyboardDragRef.current?.pointerId !==
-                                    e.pointerId
-                                ) {
-                                    return;
-                                }
-                                updateKeyboardDrag(e.clientY);
-                            }}
-                            onPointerUp={(e) => {
-                                if (
-                                    keyboardDragRef.current?.pointerId !==
-                                    e.pointerId
-                                ) {
-                                    return;
-                                }
-                                updateKeyboardDrag(e.clientY);
-                                persistKeyboardHeight(
-                                    keyboardDragRef.current.lastPercent,
-                                );
-                                keyboardDragRef.current = null;
-                                e.currentTarget.releasePointerCapture(
-                                    e.pointerId,
-                                );
-                            }}
-                            onPointerCancel={(e) => {
-                                if (
-                                    keyboardDragRef.current?.pointerId !==
-                                    e.pointerId
-                                ) {
-                                    return;
-                                }
-                                persistKeyboardHeight(
-                                    keyboardDragRef.current.lastPercent,
-                                );
-                                keyboardDragRef.current = null;
-                            }}
-                            onKeyDown={(e) => {
-                                if (e.key === "ArrowUp") {
-                                    e.preventDefault();
-                                    persistKeyboardHeight(
-                                        keyboardHeightPercent + 5,
-                                    );
-                                }
-                                if (e.key === "ArrowDown") {
-                                    e.preventDefault();
-                                    persistKeyboardHeight(
-                                        keyboardHeightPercent - 5,
-                                    );
-                                }
-                            }}
-                        >
-                            <div className="h-1 w-12 rounded-full bg-white/25" />
-                        </div>
-                    </div>
+                    <KeyboardHeightHandle
+                        onPointerDown={onPointerDown}
+                        onPointerMove={onPointerMove}
+                        onPointerUp={onPointerUp}
+                    />
                     <div className="flex justify-between items-center">
                         <div className="flex gap-2 items-center h-10">
                             <div className="flex items-center h-full">

--- a/src/components/bill-editor/keyboard-height-handle.tsx
+++ b/src/components/bill-editor/keyboard-height-handle.tsx
@@ -1,0 +1,24 @@
+import type { PointerEventHandler } from "react";
+
+export default function KeyboardHeightHandle({
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+}: {
+    onPointerDown: PointerEventHandler<HTMLDivElement>;
+    onPointerMove: PointerEventHandler<HTMLDivElement>;
+    onPointerUp: PointerEventHandler<HTMLDivElement>;
+}) {
+    return (
+        <div className="flex justify-center">
+            <div
+                className="flex h-4 w-16 touch-none select-none items-center justify-center rounded-full cursor-row-resize"
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <div className="h-1 w-12 rounded-full bg-white/25" />
+            </div>
+        </div>
+    );
+}

--- a/src/components/bill-editor/use-keyboard-height.ts
+++ b/src/components/bill-editor/use-keyboard-height.ts
@@ -1,0 +1,145 @@
+import {
+    type PointerEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { useIsDesktop } from "@/hooks/use-media-query";
+import { usePreferenceStore } from "@/store/preference";
+
+type KeyboardHeightBounds = {
+    min: number;
+    max: number;
+};
+
+const normalizeKeyboardHeightPercent = (value: number) =>
+    Math.max(0, Math.min(100, Math.round(value)));
+
+const getKeyboardHeightBounds = (isDesktop: boolean): KeyboardHeightBounds => {
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    if (isDesktop) {
+        return {
+            min: 280,
+            max: Math.min(
+                460,
+                Math.max(360, Math.round(viewportHeight * 0.56)),
+            ),
+        };
+    }
+    const min = Math.round(Math.min(300, Math.max(280, viewportHeight * 0.36)));
+    const max = Math.round(
+        Math.min(520, Math.max(min + 100, viewportHeight * 0.62)),
+    );
+    return { min, max };
+};
+
+const getKeyboardHeight = (percent: number, bounds: KeyboardHeightBounds) => {
+    const ratio = normalizeKeyboardHeightPercent(percent) / 100;
+    return Math.round(bounds.min + (bounds.max - bounds.min) * ratio);
+};
+
+const setKeyboardHeightPercent = (value: number) => {
+    const next = normalizeKeyboardHeightPercent(value);
+    usePreferenceStore.setState((prev) => ({
+        ...prev,
+        keyboardHeight: next,
+    }));
+};
+
+export function useKeyboardHeight() {
+    const isDesktop = useIsDesktop();
+    const keyboardHeightPercent = usePreferenceStore((state) =>
+        normalizeKeyboardHeightPercent(state.keyboardHeight ?? 50),
+    );
+    const [keyboardHeightBounds, setKeyboardHeightBounds] = useState(() =>
+        getKeyboardHeightBounds(isDesktop),
+    );
+    const keyboardDragRef = useRef<{
+        pointerId: number;
+        startY: number;
+        startPercent: number;
+    } | null>(null);
+
+    useEffect(() => {
+        const updateBounds = () => {
+            setKeyboardHeightBounds(getKeyboardHeightBounds(isDesktop));
+        };
+        updateBounds();
+
+        const viewport = window.visualViewport;
+        window.addEventListener("resize", updateBounds);
+        viewport?.addEventListener("resize", updateBounds);
+
+        return () => {
+            window.removeEventListener("resize", updateBounds);
+            viewport?.removeEventListener("resize", updateBounds);
+        };
+    }, [isDesktop]);
+
+    const keyboardHeight = useMemo(
+        () => getKeyboardHeight(keyboardHeightPercent, keyboardHeightBounds),
+        [keyboardHeightBounds, keyboardHeightPercent],
+    );
+
+    const updateKeyboardDrag = useCallback(
+        (clientY: number) => {
+            const drag = keyboardDragRef.current;
+            if (!drag) {
+                return;
+            }
+            const distance =
+                keyboardHeightBounds.max - keyboardHeightBounds.min;
+            if (distance <= 0) {
+                return;
+            }
+            setKeyboardHeightPercent(
+                drag.startPercent + ((drag.startY - clientY) / distance) * 100,
+            );
+        },
+        [keyboardHeightBounds],
+    );
+
+    const onPointerDown = useCallback(
+        (e: PointerEvent<HTMLDivElement>) => {
+            keyboardDragRef.current = {
+                pointerId: e.pointerId,
+                startY: e.clientY,
+                startPercent: keyboardHeightPercent,
+            };
+            e.currentTarget.setPointerCapture(e.pointerId);
+        },
+        [keyboardHeightPercent],
+    );
+
+    const onPointerMove = useCallback(
+        (e: PointerEvent<HTMLDivElement>) => {
+            if (keyboardDragRef.current?.pointerId !== e.pointerId) {
+                return;
+            }
+            updateKeyboardDrag(e.clientY);
+        },
+        [updateKeyboardDrag],
+    );
+
+    const onPointerUp = useCallback(
+        (e: PointerEvent<HTMLDivElement>) => {
+            if (keyboardDragRef.current?.pointerId !== e.pointerId) {
+                return;
+            }
+            updateKeyboardDrag(e.clientY);
+            keyboardDragRef.current = null;
+            e.currentTarget.releasePointerCapture(e.pointerId);
+        },
+        [updateKeyboardDrag],
+    );
+
+    return {
+        keyboardHeight,
+        keyboardHeightPercent,
+        onPointerDown,
+        onPointerMove,
+        onPointerUp,
+    };
+}

--- a/src/components/keyboard.tsx
+++ b/src/components/keyboard.tsx
@@ -41,6 +41,16 @@ type ButtonValue = string;
 // --- Context ---
 const CalculatorContext = createContext<CalculatorContextType | null>(null);
 
+const useCalculatorContext = () => {
+    const ctx = useContext(CalculatorContext);
+    if (!ctx) {
+        throw new Error(
+            "Calculator components must be used within Calculator.Root",
+        );
+    }
+    return ctx;
+};
+
 const getLayout = (multiplyKey?: "double-zero" | "triple-zero") => [
     { label: "1", cols: 2 },
     { label: "2", cols: 2 },
@@ -261,13 +271,13 @@ export const CalculatorRoot = ({
 };
 
 export const CalculatorValue = ({ className }: { className?: string }) => {
-    const { formula } = useContext(CalculatorContext)!;
+    const { formula } = useCalculatorContext();
     return (
         <div data-calculator-value className={cn(className)}>
             {toText(formula)
                 .split("")
                 .map((v, i) => (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                    // biome-ignore lint/suspicious/noArrayIndexKey: calculator digits are positional
                     <span key={i}>{v === "x" ? "×" : v}</span>
                 ))}
         </div>
@@ -282,9 +292,14 @@ export const CalculatorKeyboard = ({
     onKey?: (v: string) => void;
 }) => {
     const t = useIntl();
-    const { handleButtonClick, Layout } = useContext(CalculatorContext)!;
+    const { handleButtonClick, Layout } = useCalculatorContext();
     return (
-        <div className={cn("grid grid-cols-8 gap-2", className)}>
+        <div
+            className={cn(
+                "grid h-full min-h-0 grid-cols-8 grid-rows-4 gap-1 sm:gap-2",
+                className,
+            )}
+        >
             {Layout.map((row) => (
                 <Button
                     variant="ghost"
@@ -296,7 +311,7 @@ export const CalculatorKeyboard = ({
                     }}
                     className={cn(
                         (row.cols ?? 1) > 1 && "col-span-2",
-                        "h-full text-lg font-semibold bg-background/10 active:bg-background/50 transition-all",
+                        "h-full min-h-0 px-2 py-1 text-base sm:px-4 sm:py-2 sm:text-lg font-semibold bg-background/10 active:bg-background/50 transition-all",
                         row.label === "c" && "bg-destructive/60",
                     )}
                 >


### PR DESCRIPTION
同样是使用过程中发现的问题
在桌面端害好 屏幕尺寸足够键盘高一点低一点没啥感觉
但是在自己手机上用就发现 键盘的高度真难受 挡着上面的分类显示 特别挤 而且找不到编辑的按钮
就算在更多设置里面调整了键盘高度到0%也没啥效果
看了一眼代码发现原来的高度调整限制还挺大的
所以在键盘上方加了一个小小的拖拽条，这样在使用键盘的时候就可以直接拖拽，而不用切出去设置键盘高度了
并且一定程度上调整了原来的高度限制，作者可以评估一下是否符合自己审美
对了，这个新的键盘拖拽行为应该是兼容原来 [pr#151](https://github.com/glink25/Cent/pull/151) 里添加的更多设置-键盘高度的，拖拽键盘的同时会更新设置值。

<table>
<tr>
<td>
<img  alt="image" src="https://github.com/user-attachments/assets/3201b11d-3f02-4c1d-ae37-20c4cb1cae52" />
</td>
<td>
<img  alt="image" src="https://github.com/user-attachments/assets/cbcac832-9367-433f-93b7-8a47f4d0195d" />
</td>
</tr>
</table>