### PR TITLE
feat(assistant): add debug panel and import-bills tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,11 @@ dist-ssr
 
 # ai customize
 .claude
+.cursor
 
 # Rust build artifacts
 src-tauri/target
 
 src-tauri/gen
 src-tauri/binaries
+.pnpm-store

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
 			"!**/public",
 			"!.*",
 			"!src/locale/lang/**/*.json",
-			"!**/*.config.js"
+			"!**/*.config.js",
+			"!scripts"
 		]
 	},
 	"formatter": {

--- a/src/components/assistant/debug-log.ts
+++ b/src/components/assistant/debug-log.ts
@@ -1,0 +1,80 @@
+import { create } from "zustand";
+import type { Tool } from "@/assistant";
+
+export type ToolLogEntry = {
+    id: number;
+    name: string;
+    startedAt: number;
+    endedAt?: number;
+    params: unknown;
+    status: "running" | "success" | "error";
+    result?: unknown;
+    error?: string;
+};
+
+type DebugLogState = {
+    entries: ToolLogEntry[];
+    panelOpen: boolean;
+    push: (entry: Omit<ToolLogEntry, "id">) => number;
+    update: (id: number, patch: Partial<ToolLogEntry>) => void;
+    clear: () => void;
+    setPanelOpen: (v: boolean) => void;
+};
+
+let _id = 0;
+const MAX_ENTRIES = 200;
+
+export const useDebugLogStore = create<DebugLogState>((set) => ({
+    entries: [],
+    panelOpen: false,
+    push: (entry) => {
+        const id = ++_id;
+        set((state) => {
+            const next = [...state.entries, { ...entry, id }];
+            if (next.length > MAX_ENTRIES)
+                next.splice(0, next.length - MAX_ENTRIES);
+            return { entries: next };
+        });
+        return id;
+    },
+    update: (id, patch) =>
+        set((state) => ({
+            entries: state.entries.map((e) =>
+                e.id === id ? { ...e, ...patch } : e,
+            ),
+        })),
+    clear: () => set({ entries: [] }),
+    setPanelOpen: (v) => set({ panelOpen: v }),
+}));
+
+export function withDebugLog<A, R>(tool: Tool<A, R>): Tool<A, R> {
+    return {
+        ...tool,
+        handler: async (arg, ctx) => {
+            const store = useDebugLogStore.getState();
+            const id = store.push({
+                name: tool.name,
+                startedAt: Date.now(),
+                params: arg,
+                status: "running",
+            });
+            try {
+                const result = await tool.handler(arg, ctx);
+                useDebugLogStore.getState().update(id, {
+                    status: "success",
+                    result,
+                    endedAt: Date.now(),
+                });
+                return result;
+            } catch (error) {
+                useDebugLogStore.getState().update(id, {
+                    status: "error",
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                    endedAt: Date.now(),
+                });
+                throw error;
+            }
+        },
+    };
+}

--- a/src/components/assistant/debug-panel.tsx
+++ b/src/components/assistant/debug-panel.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from "react";
+import { Button } from "../ui/button";
+import { type ToolLogEntry, useDebugLogStore } from "./debug-log";
+
+function StatusBadge({ status }: { status: ToolLogEntry["status"] }) {
+    const color =
+        status === "running"
+            ? "bg-yellow-500/20 text-yellow-700 dark:text-yellow-300"
+            : status === "success"
+              ? "bg-green-500/20 text-green-700 dark:text-green-300"
+              : "bg-red-500/20 text-red-700 dark:text-red-300";
+    return (
+        <span className={`px-1.5 py-0.5 rounded text-[10px] ${color}`}>
+            {status}
+        </span>
+    );
+}
+
+function Entry({ entry }: { entry: ToolLogEntry }) {
+    const [open, setOpen] = useState(false);
+    const duration =
+        entry.endedAt !== undefined ? entry.endedAt - entry.startedAt : null;
+    return (
+        <div className="border rounded p-1.5 bg-background">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className="w-full flex items-center gap-2 text-left cursor-pointer hover:bg-accent/40 rounded px-1 py-0.5"
+            >
+                <i
+                    className={`size-3 ${
+                        open
+                            ? "icon-[mdi--chevron-down]"
+                            : "icon-[mdi--chevron-right]"
+                    }`}
+                ></i>
+                <span className="font-mono text-xs flex-1 truncate">
+                    {entry.name}
+                </span>
+                <StatusBadge status={entry.status} />
+                {duration !== null && (
+                    <span className="opacity-60 text-[10px]">{duration}ms</span>
+                )}
+            </button>
+            {open && (
+                <div className="mt-1 space-y-1 px-1">
+                    <div>
+                        <div className="text-[10px] opacity-60">params</div>
+                        <pre className="bg-muted rounded p-1 text-[10px] overflow-x-auto select-text whitespace-pre-wrap break-all">
+                            {JSON.stringify(entry.params, null, 2)}
+                        </pre>
+                    </div>
+                    {entry.status === "success" && (
+                        <div>
+                            <div className="text-[10px] opacity-60">result</div>
+                            <pre className="bg-muted rounded p-1 text-[10px] overflow-x-auto select-text whitespace-pre-wrap break-all">
+                                {JSON.stringify(entry.result, null, 2)}
+                            </pre>
+                        </div>
+                    )}
+                    {entry.status === "error" && (
+                        <div>
+                            <div className="text-[10px] opacity-60 text-destructive">
+                                error
+                            </div>
+                            <pre className="bg-destructive/10 text-destructive rounded p-1 text-[10px] overflow-x-auto select-text whitespace-pre-wrap break-all">
+                                {entry.error}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function DebugLogPanel() {
+    const open = useDebugLogStore((s) => s.panelOpen);
+    const setOpen = useDebugLogStore((s) => s.setPanelOpen);
+    const entries = useDebugLogStore((s) => s.entries);
+    const clear = useDebugLogStore((s) => s.clear);
+    const reversed = useMemo(() => [...entries].reverse(), [entries]);
+    const runningCount = entries.filter((e) => e.status === "running").length;
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen(!open)}
+                className="absolute top-2 left-2 z-10 flex items-center gap-1 rounded-full border bg-background px-2 py-1 text-[10px] shadow hover:bg-accent cursor-pointer"
+                title="Tool log"
+            >
+                <i className="icon-[mdi--bug-outline] size-3.5"></i>
+                <span>log</span>
+                {entries.length > 0 && (
+                    <span className="bg-muted rounded-full px-1.5">
+                        {entries.length}
+                    </span>
+                )}
+                {runningCount > 0 && (
+                    <span className="size-1.5 rounded-full bg-yellow-500 animate-pulse" />
+                )}
+            </button>
+            {open && (
+                <div className="absolute top-10 left-2 right-2 z-20 max-h-[55%] bg-background border rounded-md shadow-lg flex flex-col overflow-hidden">
+                    <div className="flex items-center justify-between px-2 py-1 border-b">
+                        <div className="text-xs font-medium">
+                            Tool log ({entries.length})
+                        </div>
+                        <div className="flex gap-1">
+                            <Button
+                                variant="ghost"
+                                className="h-6 px-2 text-xs"
+                                onClick={clear}
+                            >
+                                clear
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                className="h-6 w-6 p-0"
+                                onClick={() => setOpen(false)}
+                            >
+                                <i className="icon-[mdi--close] size-3.5"></i>
+                            </Button>
+                        </div>
+                    </div>
+                    <div className="flex-1 overflow-y-auto p-1.5 space-y-1.5 text-xs">
+                        {reversed.length === 0 ? (
+                            <div className="text-center opacity-50 py-6">
+                                (no tool calls yet)
+                            </div>
+                        ) : (
+                            reversed.map((entry) => (
+                                <Entry key={entry.id} entry={entry} />
+                            ))
+                        )}
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/assistant/main.tsx
+++ b/src/components/assistant/main.tsx
@@ -23,6 +23,7 @@ import { showFilePicker } from "@/components/file-picker";
 import { useIntl } from "@/locale";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { DebugLogPanel } from "./debug-panel";
 import { MessageBubble } from "./message";
 import { useAssistantChatStore } from "./state";
 import { CentAIConfig } from "./tools";
@@ -330,6 +331,7 @@ function Content() {
 
     return (
         <div className="w-full flex-1 flex flex-col overflow-hidden relative">
+            <DebugLogPanel />
             <div className="hidden md:flex justify-center items-center py-2 h-12">
                 <div>{t("ai-assistant")}</div>
                 <div className="absolute right-2">

--- a/src/components/assistant/tools/env.ts
+++ b/src/components/assistant/tools/env.ts
@@ -1,9 +1,12 @@
 import dayjs from "dayjs";
+import { StorageAPI } from "@/api/storage";
 import type { ViewType } from "@/components/stat/date-slice";
 import type { FocusType } from "@/components/stat/focus-type";
 import { BillCategories } from "@/ledger/category";
 import type { BillFilterView } from "@/ledger/extra-type";
+import { useBookStore } from "@/store/book";
 import { useLedgerStore } from "@/store/ledger";
+import { useUserStore } from "@/store/user";
 
 export type EnvArg = {
     filterView?: BillFilterView;
@@ -19,13 +22,15 @@ export function setEnv(env: EnvArg) {
 }
 
 function transformEnvToPrompt(env?: EnvArg) {
-    if (!env) {
-        return "";
-    }
-
     const store = useLedgerStore.getState();
     const meta = store.infos?.meta;
     const creators = store.infos?.creators ?? [];
+
+    // 当前选中账本
+    const bookState = useBookStore.getState();
+    const currentBook = bookState.books.find(
+        (b) => b.id === bookState.currentBookId,
+    );
 
     // 获取所有分类（默认分类 + 自定义分类）
     const allCategories = [...BillCategories, ...(meta?.categories ?? [])];
@@ -35,11 +40,39 @@ function transformEnvToPrompt(env?: EnvArg) {
 
     const parts: string[] = [];
 
+    // 当前用户
+    const userState = useUserStore.getState();
+    const isUserLoggedIn =
+        userState.id !== -1 && userState.id !== 0 && Boolean(userState.id);
+
     // 基础信息
     parts.push("## 当前环境信息");
     parts.push("");
     parts.push(`**当前时间**: ${dayjs().format("YYYY-MM-DD HH:mm:ss")}`);
+    if (isUserLoggedIn) {
+        parts.push(
+            `**当前用户**: ${userState.name || "(未命名)"} (id: ${userState.id})`,
+        );
+    } else {
+        parts.push("**当前用户**: 未登录");
+    }
+    parts.push(
+        `**登录方式**: ${StorageAPI.name}${StorageAPI.type ? ` (${StorageAPI.type})` : ""}`,
+    );
+    if (currentBook) {
+        parts.push(
+            `**当前账本**: ${currentBook.name}${currentBook.id ? ` (id: ${currentBook.id})` : ""}`,
+        );
+    } else if (bookState.currentBookId) {
+        parts.push(`**当前账本 ID**: ${bookState.currentBookId}`);
+    } else {
+        parts.push("**当前账本**: 未选中");
+    }
     parts.push("");
+
+    if (!env) {
+        return parts.join("\n");
+    }
 
     // 过滤视图信息
     if (env.filterView) {

--- a/src/components/assistant/tools/index.ts
+++ b/src/components/assistant/tools/index.ts
@@ -1,8 +1,10 @@
 import type { Tool } from "@/assistant";
+import { withDebugLog } from "../debug-log";
 import { EnvTool } from "./env-tool";
 import {
     AnalyzeBillsTool,
     GetAccountMetaTool,
+    ImportBillsTool,
     QueryBillsTool,
 } from "./ledger-tools";
 import { PlaygroundSkill, PlaygroundTool } from "./playground";
@@ -14,8 +16,9 @@ export const CentAIConfig = {
         AnalyzeBillsTool,
         QueryBillsTool,
         GetAccountMetaTool,
+        ImportBillsTool,
         PlaygroundTool,
-    ] as Tool[],
+    ].map((t) => withDebugLog(t as Tool)) as Tool[],
     skills: [PlaygroundSkill],
     provider: CentAIProvider,
     systemPrompt: `

--- a/src/components/assistant/tools/ledger-tools/import-tool.ts
+++ b/src/components/assistant/tools/ledger-tools/import-tool.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+import { createTool } from "@/assistant";
+import type { PreviewState } from "@/components/data-manager/preview";
+import {
+    importFromPreviewResult,
+    showImportPreview,
+} from "@/components/data-manager/preview-form";
+import type { Bill, BillCategory, BillTag, GlobalMeta } from "@/ledger/type";
+
+const billSchema = z
+    .object({
+        id: z
+            .string()
+            .describe(
+                "账单的唯一标识，应保证唯一。建议使用 crypto.randomUUID()，或 time 与序号拼接形式。",
+            ),
+        type: z
+            .enum(["income", "expense"])
+            .describe("账单类型：income(收入) 或 expense(支出)。"),
+        categoryId: z
+            .string()
+            .describe(
+                "账单分类的 id。必须引用一个已存在的分类（先调用 getAccountMeta 获取可用分类），" +
+                    "或者在 meta.categories 中新增自定义分类后再使用其 id。",
+            ),
+        creatorId: z
+            .union([z.number(), z.string()])
+            .describe("创建者 id。若不确定，可填写 0。"),
+        comment: z
+            .string()
+            .optional()
+            .describe("备注。导入时不确定的信息也可保存在这里。"),
+        amount: z
+            .number()
+            .int()
+            .describe(
+                "整数金额，单位为分的一万分之一（实际金额 × 10000）。" +
+                    "例如 ¥12.34 应写作 123400；¥0.01 应写作 100。" +
+                    "切勿直接传入人民币元值。",
+            ),
+        time: z
+            .number()
+            .describe(
+                "账单发生时间，毫秒级 epoch 时间戳（Date.now() 同单位）。",
+            ),
+        images: z
+            .array(z.string())
+            .optional()
+            .describe(
+                "账单图片附件，字符串数组。每个元素可以是 " +
+                    "(1) data: URI（如 'data:image/png;base64,...'）；" +
+                    "(2) 公网可访问的 http(s) URL。请勿传入本地文件路径。",
+            ),
+        location: z
+            .object({
+                latitude: z.number(),
+                longitude: z.number(),
+                accuracy: z.number(),
+            })
+            .optional()
+            .describe("地理位置（可选）。"),
+        tagIds: z
+            .array(z.string())
+            .optional()
+            .describe(
+                "标签 id 数组。必须引用已存在的标签 id（通过 getAccountMeta 获取），" +
+                    "或在 meta.tags 中新增标签后再使用其 id。",
+            ),
+        currency: z
+            .object({
+                base: z.string().describe("记账时的本位币代码，如 CNY。"),
+                target: z.string().describe("实际记账币种代码。"),
+                amount: z
+                    .number()
+                    .describe(
+                        "原始记账金额（人类可读金额，例如 12.34），不需要 ×10000。",
+                    ),
+            })
+            .optional()
+            .describe("多币种信息（可选）。"),
+    })
+    .describe("单笔账单，字段含义对应 Cent 的 Bill 类型。");
+
+const categorySchema = z
+    .object({
+        type: z.enum(["income", "expense"]),
+        name: z.string(),
+        id: z.string(),
+        icon: z.string().optional().default(""),
+        color: z.string().optional().default(""),
+        customName: z.literal(true).describe("新增分类必须为 true。"),
+        parent: z
+            .string()
+            .optional()
+            .describe("父类 id，留空表示该项本身就是父类。"),
+    })
+    .describe(
+        "新增的自定义分类。仅在已有分类中没有合适项时新增，否则应复用 getAccountMeta 返回的已有分类。",
+    );
+
+const tagSchema = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+    })
+    .describe("新增的标签。仅在已有标签中没有合适项时新增。");
+
+const metaSchema = z
+    .object({
+        categories: z
+            .array(categorySchema)
+            .optional()
+            .describe("本次导入需要新增的分类。"),
+        tags: z
+            .array(tagSchema)
+            .optional()
+            .describe("本次导入需要新增的标签。"),
+    })
+    .partial()
+    .optional()
+    .describe(
+        "可选的全局配置增量。只放本次导入新增的分类/标签，不要重复已有项。",
+    );
+
+const argSchema = z
+    .object({
+        items: z
+            .array(billSchema)
+            .min(1)
+            .describe("待导入的账单列表，至少一条。"),
+        meta: metaSchema,
+    })
+    .describe(
+        "符合 Cent ExportedJSON 结构的导入数据。生成前请先调用 getAccountMeta 获取" +
+            "现有分类与标签，复用已有的 id；只有在没有合适项时才在 meta 中新增。",
+    );
+
+const returnSchema = z.object({
+    ok: z.boolean().describe("是否成功导入。"),
+    imported: z
+        .number()
+        .optional()
+        .describe("成功导入的账单数量（ok=true 时存在）。"),
+    strategy: z
+        .enum(["append", "overlap"])
+        .optional()
+        .describe("用户选择的导入策略（ok=true 时存在）。"),
+    reason: z
+        .string()
+        .optional()
+        .describe("失败原因，例如 'user_cancelled'（ok=false 时存在）。"),
+});
+
+// —— 静态类型校验：确保 Zod schema 推断出的形状与 Cent 真实类型保持一致。
+// 任意 schema 与对应类型偏离时，下方的 const 赋值会立刻产生 ts 错误。
+// 注意：ExportedJSON.items 是 Full<Bill>[]（带 __create_at 等仓储字段），
+// 而 AI 生成的是裸 Bill，仓储元数据由导入流程补齐，因此这里只校验到 Bill。
+const _assertBillSchema: Bill = null as unknown as z.infer<typeof billSchema>;
+const _assertCategorySchema: BillCategory = null as unknown as z.infer<
+    typeof categorySchema
+>;
+const _assertTagSchema: BillTag = null as unknown as z.infer<typeof tagSchema>;
+const _assertMetaSchema: Partial<GlobalMeta> = null as unknown as NonNullable<
+    z.infer<typeof metaSchema>
+>;
+const _assertArgItems: Bill[] = null as unknown as z.infer<
+    typeof argSchema
+>["items"];
+void _assertBillSchema;
+void _assertCategorySchema;
+void _assertTagSchema;
+void _assertMetaSchema;
+void _assertArgItems;
+
+export const ImportBillsTool = createTool({
+    name: "importBills",
+    describe:
+        "导入一批 AI 生成的账单到 Cent。调用前应先通过 getAccountMeta 获取已有的分类和标签，" +
+        "以便为每条账单选择合理的 categoryId / tagIds。金额字段 amount 必须为整数 ×10000；" +
+        "时间字段 time 为毫秒 epoch；图片可用 data: URI 内联。" +
+        "调用后会弹出导入预览对话框，由用户最终确认是否写入账本。",
+    argSchema,
+    returnSchema,
+    handler: async (arg) => {
+        const previewInput: PreviewState = {
+            bills: arg.items as unknown as PreviewState["bills"],
+            meta: arg.meta as unknown as PreviewState["meta"],
+        };
+        const res = await showImportPreview(previewInput);
+        if (!res) {
+            return { ok: false, reason: "user_cancelled" };
+        }
+        await importFromPreviewResult(res);
+        return {
+            ok: true,
+            imported: arg.items.length,
+            strategy: res.strategy,
+        };
+    },
+});

--- a/src/components/assistant/tools/ledger-tools/index.ts
+++ b/src/components/assistant/tools/ledger-tools/index.ts
@@ -4,6 +4,8 @@ import type { ExportedJSON } from "@/ledger/type";
 import { useLedgerStore } from "@/store/ledger";
 import { analyzeBills, getAccountMeta, queryBills } from "./ledger-functions";
 
+export { ImportBillsTool } from "./import-tool";
+
 const queryLikeSchema = z.object({
     startTime: z.string().optional().describe("YYYY-MM-DD"),
     endTime: z.string().optional().describe("YYYY-MM-DD"),

--- a/src/components/data-manager/index.tsx
+++ b/src/components/data-manager/index.tsx
@@ -11,11 +11,7 @@ import modal from "../modal";
 import { Button } from "../ui/button";
 import { prepareExportFile, processImportFile } from "./exportable";
 import { showOncentImport } from "./oncent";
-import {
-    ImportPreviewProvider,
-    importFromPreviewResult,
-    showImportPreview,
-} from "./preview-form";
+import { importFromPreviewResult, showImportPreview } from "./preview-form";
 import { SmartImport } from "./smart-import";
 
 const [SmartImportProvider, showSmartImport] = createConfirmProvider(
@@ -149,7 +145,6 @@ function Form({ onCancel }: { onCancel?: () => void }) {
                     </div>
                 </div>
             </div>
-            <ImportPreviewProvider />
             <SmartImportProvider />
         </PopupLayout>
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 
+import { ImportPreviewProvider } from "./components/data-manager/preview-form";
 import Login from "./components/login";
 import { initIntl, LocaleProvider } from "./locale/index";
 import { usePreferenceStore } from "./store/preference";
@@ -22,6 +23,7 @@ initIntl(lang).then(() => {
                     <Rooot />
                 </Suspense>
                 <Login />
+                <ImportPreviewProvider />
             </LocaleProvider>
         </StrictMode>,
     );


### PR DESCRIPTION
从 tauri 分支回抽至 main，修正 main → tauri 的分支流动方向（此前这组通用功能被错误地先在 tauri 上实现）。

## 范围
仅涵盖 "assistant 新增工具 + debug 面板" 两项纯通用改动，不含任何 tauri 专属代码（已用 `grep @tauri-apps / src-tauri / invoke / tauri-oauth` 复核零命中）。

## 改动
- **debug 面板**：`src/components/assistant/{debug-log.ts,debug-panel.tsx}`；`tools/index.ts` 通过 `withDebugLog` 包装所有工具，自动记录调用入参/返回/异常与耗时；`assistant/main.tsx` 挂载 DebugLogPanel。
- **新工具 ImportBillsTool**：接受符合 Cent 结构的账单列表，调用 data-manager 的 import preview 让用户确认后写入账本。
- **Env 工具增强**：`env.ts` 额外输出当前登录态、登录方式、当前账本。
- **ImportPreviewProvider 上移**：从 `data-manager/index.tsx` 内部移到 `src/main.tsx` 顶层，使 ImportBillsTool 可独立触发预览。
- **配置**：`.gitignore` 追加 `.cursor` / `.pnpm-store`；`biome.json` ignore 列表追加 `scripts`（对 web 无副作用）。

## 测试
`pnpm build`（含 lint）通过；无新增 tauri 依赖。

## 后续
合并后会再把 `main` 合回 `tauri` 以恢复正常分支流动方向；tauri 分支工作树内容保持不变（由 `backup/tauri-before-reorder` tag 校验）。