### PR TITLE
fix: 修复移动端（特别是 Samsung 机型）分类和子分类文字显示不全的问题

### DIFF
--- a/apps/cent/src/components/bill-editor/form.tsx
+++ b/apps/cent/src/components/bill-editor/form.tsx
@@ -406,8 +406,8 @@ export default function EditorForm({
                 }
             >
                 {/* categories */}
-                <div className="flex-1 flex-shrink-0 overflow-y-auto min-h-[80px] scrollbar-hidden flex flex-col px-2 text-sm font-medium gap-2">
-                    <div className="flex flex-col min-h-[80px] grow-[2] shrink overflow-y-auto scrollbar-hidden w-full">
+                <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hidden flex flex-col px-2 text-sm font-medium gap-2">
+                    <div className="flex-shrink-0">
                         <div
                             className={cn(
                                 "grid gap-1",
@@ -439,7 +439,7 @@ export default function EditorForm({
                         </div>
                     </div>
                     {(subCategories?.length ?? 0) > 0 && (
-                        <div className="flex flex-col min-h-[68px] grow-[1] shrink max-h-fit overflow-y-auto rounded-md border p-2 shadow scrollbar-hidden">
+                        <div className="flex-1 min-h-[68px] overflow-y-auto rounded-md border p-2 shadow scrollbar-hidden">
                             <div
                                 className={cn(
                                     "grid gap-1",

--- a/apps/cent/src/components/category/item.tsx
+++ b/apps/cent/src/components/category/item.tsx
@@ -20,7 +20,7 @@ export function CategoryItem({
         <button
             type="button"
             className={cn(
-                `rounded-lg border flex-1 py-1 px-2 h-8 flex items-center justify-center whitespace-nowrap cursor-pointer`,
+                `rounded-lg border py-2 px-3 min-h-[40px] flex items-center justify-center gap-2 cursor-pointer`,
                 selected
                     ? "bg-slate-700 text-white "
                     : "bg-stone-200  text-light-900 dark:bg-stone-500",
@@ -33,7 +33,9 @@ export function CategoryItem({
                 icon={category.icon}
                 className="w-4 h-4 flex-shrink-0"
             />
-            <div className="mx-2 truncate">{category.name}</div>
+            <div className="text-sm break-words text-center">
+                {category.name}
+            </div>
         </button>
     );
 }

--- a/apps/cent/src/ledger/utils.ts
+++ b/apps/cent/src/ledger/utils.ts
@@ -224,9 +224,7 @@ export const intlCategory = <
 };
 
 export const categoriesGridClassName = (cs: BillCategory[] | undefined) =>
-    cs?.some((v) => v.name.length > 2)
-        ? "grid-cols-[repeat(auto-fill,minmax(120px,1fr))]"
-        : "grid-cols-[repeat(auto-fill,minmax(80px,1fr))]";
+    "grid-cols-[repeat(auto-fill,minmax(100px,1fr))]";
 
 /**
  * 属性合并辅助函数：处理 A, B, Default 三者之间的冲突


### PR DESCRIPTION
修复 #333 
- 优化 CategoryItem 组件：移除固定高度和文字截断，改为自适应高度和换行
- 优化网格布局：统一使用更稳定的布局方案
- 优化整体 flex 布局：添加 min-h-0 确保滚动正常工作

我让Trae帮忙改的代码，麻烦作者看下有没有什么问题。
